### PR TITLE
v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 2.1.0
+
+- `bones_ui` CLI:
+  - Added `test` command, for Bones_UI unit tests. 
+- Added libraries:
+  - `bones_ui_test` to import the Bones_UI Test tools.
+  - `bones_ui_test_clit` to import the Bones_UI Test CLI (used by `test` command).
+- `UIComponent`
+  - Added `waiteRender`, `callRenderAndWait`, `querySelector`, `querySelectorAll`.
+    - These methods can be useful in unit tests. 
+- `ElementExtension`:
+- Fix `UINavigator` behavior when `findNavigable` can't find a `UINavigableComponent` for the route.
+- intl_messages: ^2.0.4
+- dom_tools: ^2.1.8
+- archive: ^3.3.5
+- test: ^1.22.0
+- test_api: 0.4.17
+- test_core: 0.4.21
+- path: ^1.8.3
+
 ## 2.0.27
 
 - `UIInputTable`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@
 - dom_tools: ^2.1.8
 - archive: ^3.3.5
 - test: ^1.22.0
-- test_api: 0.4.17
-- test_core: 0.4.21
+- test_api: ^0.4.17
+- test_core: ^0.4.21
 - path: ^1.8.3
 
 ## 2.0.27

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Also see the [App example @ GitHub][app_example]:
 
 You can create unit tests for your `Bones_UI` app.
 
-Simpe example with a login test:
+A Simple example with a login test:
 ```dart
 @TestOn('browser')
 import 'package:bones_ui/bones_ui_test.dart';
@@ -169,7 +169,7 @@ void main() async {
       uiRoot.clear();
     });
 
-    test('top-menu: initial routes', () async {
+    test('menu: routes', () async {
       await uiRoot.callRenderAndWait();
       await testUISleep(ms: 100);
 

--- a/lib/bones_ui.dart
+++ b/lib/bones_ui.dart
@@ -1,6 +1,6 @@
 /// Bone UI
 ///
-/// Easy and simple Web User Interface for Dart.
+/// Easy and simple Web User Interface Framework for Dart.
 library bones_ui;
 
 export 'src/bones_ui.dart';

--- a/lib/bones_ui_kit.dart
+++ b/lib/bones_ui_kit.dart
@@ -1,6 +1,6 @@
-/// Bone UI Kit
+/// Bone UI - Kit
 ///
-/// Easy and simple Web User Interface Framework for Dart.
+/// Exports `bones_ui` + extra useful packages.
 library bones_ui_kit;
 
 export 'package:dom_builder/dom_builder.dart';

--- a/lib/bones_ui_test.dart
+++ b/lib/bones_ui_test.dart
@@ -1,0 +1,11 @@
+/// Bone UI - Test Tools
+library bones_ui_test;
+
+export 'dart:async';
+export 'dart:html';
+
+export 'package:dom_builder/dom_builder.dart';
+export 'package:dom_tools/dom_tools.dart';
+
+export 'bones_ui.dart';
+export 'src/bones_ui_test_tools.dart';

--- a/lib/bones_ui_test_clit.dart
+++ b/lib/bones_ui_test_clit.dart
@@ -1,0 +1,5 @@
+/// Bone UI - Test CLI
+library bones_ui_test_cli;
+
+export 'bones_ui.dart';
+export 'src/bones_ui_test_cli.dart';

--- a/lib/src/bones_ui.dart
+++ b/lib/src/bones_ui.dart
@@ -1,3 +1,3 @@
 class BonesUI {
-  static const String version = '2.0.27';
+  static const String version = '2.1.0';
 }

--- a/lib/src/bones_ui_extension.dart
+++ b/lib/src/bones_ui_extension.dart
@@ -80,21 +80,7 @@ extension ElementExtension on Element {
   }
 }
 
-extension IterableElementExtension on Iterable<Element> {
-  /// Adds a class to all elements of this [Iterable] of [Element]s.
-  void addClass(String clazz) {
-    for (var e in this) {
-      e.classes.add(clazz);
-    }
-  }
-
-  /// Removes a class from all elements of this [Iterable] of [Element]s.
-  void removeClass(String clazz) {
-    for (var e in this) {
-      e.classes.remove(clazz);
-    }
-  }
-
+extension IterableElementExtension<E extends Element> on Iterable<E> {
   /// Returns a [List] of [UIComponent] of this [Iterable] of [Element]s.
   List<UIComponent?> get uiComponents => map((e) => e.uiComponent).toList();
 

--- a/lib/src/bones_ui_test_cli.dart
+++ b/lib/src/bones_ui_test_cli.dart
@@ -1,0 +1,668 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:bones_ui/src/bones_ui.dart';
+import 'package:collection/collection.dart';
+import 'package:path/path.dart' as pack_path;
+import 'package:test/src/runner/browser/platform.dart'; // ignore: implementation_imports
+import 'package:test/src/runner/executable_settings.dart'; // ignore: implementation_imports
+import 'package:test/test.dart';
+import 'package:test_api/src/backend/runtime.dart'; // ignore: implementation_imports
+import 'package:test_api/src/backend/suite_platform.dart'; // ignore: implementation_imports
+// ignore: implementation_imports
+import 'package:test_core/src/executable.dart' as executable;
+import 'package:test_core/src/runner/configuration.dart'; // ignore: implementation_imports
+import 'package:test_core/src/runner/hack_register_platform.dart'; // ignore: implementation_imports
+import 'package:test_core/src/runner/platform.dart'; // ignore: implementation_imports
+import 'package:test_core/src/runner/plugin/customizable_platform.dart'; // ignore: implementation_imports
+import 'package:test_core/src/runner/runner_suite.dart'; // ignore: implementation_imports
+import 'package:test_core/src/runner/suite.dart'; // ignore: implementation_imports
+import 'package:yaml/src/yaml_node.dart'; // ignore: implementation_imports
+
+const bonesUiTestCliTitle = 'Bones_UI/${BonesUI.version} - Test Tool';
+
+/// Prints the Bones_UI Test CLI title.
+void printTestCliTitle(
+    {bool showDartVersion = true,
+    bool showOSVersion = true,
+    String? testPlatform}) {
+  var dartVersion = Platform.version;
+  var os = Platform.operatingSystem;
+  var osVer = Platform.operatingSystemVersion;
+
+  var lines = [
+    bonesUiTestCliTitle,
+    if (showDartVersion) '» Dart: $dartVersion',
+    if (showOSVersion) '» OS: $os/$osVer',
+    if (testPlatform != null && testPlatform.isNotEmpty)
+      '» Platform: $testPlatform',
+  ];
+
+  printBox(lines);
+}
+
+void printBox(List<String> lines) {
+  print(
+      '╔═════════════════════════════════════════════════════════════════════\n'
+      '${lines.map((l) => '║ $l\n').join()}'
+      '╚═════════════════════════════════════════════════════════════════════');
+}
+
+Future<void> main([List<String> args = const <String>[]]) async {
+  BonesUITestRunner bonesUITestRunner;
+
+  try {
+    bonesUITestRunner = BonesUITestRunner(args: args);
+  } catch (e) {
+    print('** ERROR Parsing Bones_UI Test Tool ARGS: $args');
+    print('-- See `bones_ui test -h` OR `dart test -h` for test parameters.');
+    print(e);
+    exit(1);
+  }
+
+  printTestCliTitle(testPlatform: bonesUITestRunner.platform);
+
+  await bonesUITestRunner.execute();
+}
+
+/// A Bones_UI test runner.
+class BonesUITestRunner {
+  final BonesUIComiler bonesUIComiler;
+
+  /// The Bones_UI test config file. Default: `bones_ui_test_config.yaml`
+  late final File bonesUiTestConfigFile;
+
+  /// The Bones_UI test templat HTML file. Default: `bones_ui_test.html.tpl`
+  final String bonesUITestTemplateFileName;
+
+  /// The original arguments.
+  late final List<String> args;
+
+  /// The parsed test arguments.
+  late final Configuration parsedArgs;
+
+  /// Returns `true` if `--show-ui` was passed.
+  late final bool showUI;
+
+  Directory get bonesUICompileDir => bonesUIComiler.compileDir;
+
+  File get bonesUITestTemplateFile =>
+      File(pack_path.join(bonesUICompileDir.path, bonesUITestTemplateFileName));
+
+  BonesUITestRunner(
+      {List<String>? args,
+      Directory? compileDir,
+      String bonesUITestConfigFileName = 'bones_ui_test_config.yaml',
+      this.bonesUITestTemplateFileName = 'bones_ui_test.html.tpl'})
+      : args = args ?? <String>[],
+        bonesUIComiler = BonesUIComiler(compileDir: compileDir) {
+    var args = this.args.toList();
+
+    bonesUiTestConfigFile =
+        File(pack_path.join(bonesUICompileDir.path, bonesUITestConfigFileName));
+
+    var argHeadless = args.remove('--headless');
+    var argShowUI = args.remove('--show-ui');
+
+    showUI = argShowUI && !argHeadless;
+
+    var configuration =
+        args.isNotEmpty ? Configuration.parse(args) : Configuration.empty;
+
+    try {
+      if (File(configuration.configurationPath).existsSync()) {
+        var fileConfiguration =
+            Configuration.load(configuration.configurationPath);
+
+        configuration = fileConfiguration.merge(configuration);
+      }
+    } catch (_) {}
+
+    parsedArgs = configuration;
+  }
+
+  /// Returns `true` if running the browser in headless mode.
+  /// - Options `--show-ui` and `--pause-after-load` will deativate `headless` mode.
+  /// - See [showUI].
+  bool get headleass => !showUI && !pauseAfterLoad;
+
+  /// Returns `true` if in debug mode.
+  bool get debug => parsedArgs.debug;
+
+  /// Returns `trur` if `--pause-after-load` was passed.
+  bool get pauseAfterLoad => parsedArgs.pauseAfterLoad;
+
+  /// The parsed `--platform` parameter.
+  String? get parsedArgsPlatform =>
+      parsedArgs.suiteDefaults.runtimes.firstOrNull;
+
+  /// The selected platform to run the tests.
+  String get platform {
+    var parsedPlatform = parsedArgsPlatform;
+    return _isValidPlatform(parsedPlatform) ? parsedPlatform! : 'chrome';
+  }
+
+  bool _isValidPlatform(String? parsedPlatform) =>
+      parsedPlatform != null &&
+      parsedPlatform != 'vm' &&
+      parsedPlatform != 'node' &&
+      !parsedPlatform.contains('wasm');
+
+  /// Returns all the known platforms for the `test` package.
+  List<String> get allKnownPlatforms => <String>{
+        ...Runtime.builtIn.map((e) => e.identifier),
+        ...parsedArgs.overrideRuntimes.values.map((e) => e.identifier),
+        ...parsedArgs.defineRuntimes.values.map((e) => e.identifier),
+      }.toList();
+
+  /// Shows the usage help in the console.
+  Future<bool> showHelp() async {
+    print('\nUsage: bones_ui test [options] [files or directories...]\n');
+
+    print('Options:');
+    print('-h, --help                            Show this usage information.');
+    print(
+        '    --show-ui                         Run the tests showing the UI in the browser.');
+
+    print('\nOptions from `dart test`:');
+    print('-t, --tags                            Select a tag: -t basic');
+    print('-x, --exclude-tags                    Exclude a tag: -x slow');
+    print(
+        '-n, --name                            A substring of the name of the test to run.');
+    print(
+        '    --pause-after-load                Pauses the browser for debugging before running the tests.');
+    print(
+        '    --debug                           Run the Chrome tests in debug mode.');
+
+    print(
+        '    --timeout                         The default test timeout. For example: 15s, 2x, none, 60s (default)');
+    print(
+        '    --ignore-timeouts                 Ignore all timeouts (useful if debugging)');
+    print(
+        '    --run-skipped                     Run skipped tests instead of skipping them.');
+    print(
+        "    --no-retry                        Don't rerun tests that have retry set.");
+
+    print(
+        '    --coverage=<directory>            Gather coverage and output it to the specified directory.');
+    print(
+        '    --reporter=<option>               Set how to print test results.');
+    print(
+        '    --file-reporter                   Enable an additional reporter writing test results to a file.');
+
+    print(
+        '    --js-trace                        Emit raw JavaScript stack traces for browser tests.');
+    print(
+        '    --dart2js-args                    Pass arguments to `dart2js` compiler.');
+
+    print(
+        '\n** See `dart test --help` or https://dart.dev/tools/dart-test for more details.');
+
+    print('');
+
+    return true;
+  }
+
+  Future<void> prepare() async {
+    bonesUIComiler.prepare();
+
+    final platform = this.platform;
+    final allKnownPlatforms = this.allKnownPlatforms;
+
+    if (!allKnownPlatforms.contains(platform)) {
+      print('** Unknown platform: `$platform`');
+      print('-- Known platforms: $allKnownPlatforms');
+
+      exit(1);
+    }
+
+    final parsedPlatform = parsedArgsPlatform ?? '';
+
+    if (!_isValidPlatform(parsedPlatform) && args.contains(parsedPlatform)) {
+      print(
+          '** Ignoring `platform` parameter `$parsedPlatform`. Selected platform: `$platform`');
+    }
+  }
+
+  /// Executes the tests.
+  Future<bool> execute() async {
+    if (parsedArgs.help) {
+      return showHelp();
+    }
+
+    prepare();
+
+    var testArgs = resolveTestArgs();
+
+    await bonesUIComiler.compile();
+
+    var configurationPath = resolveTestConfigurationPath(parsedArgs);
+
+    registerPlatformPlugin([
+      Runtime.chrome,
+      Runtime.firefox,
+      Runtime.safari,
+      Runtime.internetExplorer
+    ], () => BonesUIPlatform.create(bonesUIComiler, showUI: showUI));
+
+    print(
+        '\n══════════════════════════════════════════════════════════════════════');
+    print(
+        '** Show UI: $showUI ${headleass ? '(headless)' : '(showing browser)'}');
+    print('** Test ARGS: ${testArgs.join(' ')}');
+    print('** Executing tests...\n');
+
+    testArgs.insertAll(0, [
+      '--configuration',
+      configurationPath,
+    ]);
+
+    await executable.main(testArgs);
+
+    return true;
+  }
+
+  /// Resolves the test args to pass to the `test` package.
+  List<String> resolveTestArgs() {
+    var testPlatform = platform;
+    var testPauseAfterLoad = parsedArgs.pauseAfterLoad;
+    var testDebug = parsedArgs.debug;
+    var includeTags = parsedArgs.includeTags.variables.toList();
+    var excludeTags = parsedArgs.excludeTags.variables.toList();
+    var testsNames = parsedArgs.globalPatterns;
+    var testCoverage = parsedArgs.coverage;
+    var testReporter = parsedArgs.reporter;
+    var testFileReporters = parsedArgs.fileReporters;
+    var testNoRetry = parsedArgs.noRetry;
+
+    final suiteDefaults = parsedArgs.suiteDefaults;
+
+    var testTimeout =
+        !headleass ? Timeout.none : suiteDefaults.metadata.timeout;
+
+    var testIgnoreTimeouts = suiteDefaults.ignoreTimeouts;
+    var testRunSkipped = suiteDefaults.runSkipped;
+    var testDart2jsArgs2 = suiteDefaults.dart2jsArgs;
+    var testJsTrace = suiteDefaults.jsTrace;
+
+    var testArgs = <String>[
+      '--platform',
+      testPlatform,
+      if (testPauseAfterLoad) '--pause-after-load',
+      if (testDebug || showUI) '--debug',
+      if (testTimeout !=
+          Configuration.empty.suiteDefaults.metadata.timeout) ...[
+        '--timeout',
+        testTimeout.toString()
+      ],
+      if (testIgnoreTimeouts) '--ignore-timeouts',
+      if (testRunSkipped) '--run-skipped',
+      if (testNoRetry) '--no-retry',
+      if (testReporter.isNotEmpty &&
+          testReporter != Configuration.empty.reporter) ...[
+        '--reporter',
+        testReporter
+      ],
+      if (testFileReporters.isNotEmpty)
+        ...testFileReporters.entries
+            .expand((e) => ['--file-reporter', '${e.key}:${e.value}']),
+      if (includeTags.isNotEmpty) ...includeTags.expand((t) => ['-t', t]),
+      if (excludeTags.isNotEmpty) ...excludeTags.expand((t) => ['-x', t]),
+      if (testsNames.isNotEmpty)
+        ...testsNames
+            .expand((p) => ['-n', p is RegExp ? p.pattern : p.toString()]),
+      if (testCoverage != null && testCoverage.isNotEmpty) ...[
+        '--coverage',
+        testCoverage
+      ],
+      if (testJsTrace) '--js-trace',
+      if (testDart2jsArgs2.isNotEmpty) ...[
+        '--dart2js-args',
+        testDart2jsArgs2.join(' ')
+      ]
+    ];
+
+    return testArgs;
+  }
+
+  /// Resolves the test configuration path. Defaults to [bonesUiTestConfigFile].
+  String resolveTestConfigurationPath(Configuration testConfiguration) {
+    String configurationPath;
+
+    if (testConfiguration.configurationPath == 'dart_test.yaml') {
+      if (!bonesUiTestConfigFile.existsSync()) {
+        generateBonesUITestConfigFile();
+      }
+
+      configurationPath = bonesUiTestConfigFile.path;
+    } else {
+      configurationPath = testConfiguration.configurationPath;
+    }
+
+    return configurationPath;
+  }
+
+  /// Generates the
+  void generateBonesUITestConfigFile() {
+    if (!bonesUITestTemplateFile.existsSync()) {
+      generateTestTemplateFile();
+    }
+
+    var dartTestConfigFile = File('dart_test.yaml');
+    var includeDartTestConfig = dartTestConfigFile.existsSync();
+
+    var config =
+        buildBonesUITestConfig(includeDartTestConfig, dartTestConfigFile);
+
+    bonesUiTestConfigFile.writeAsStringSync(config);
+  }
+
+  /// Builds the [bonesUiTestConfigFile] content.
+  /// - If [includeDartTestConfig] is `true` should include the [dartTestConfigFile].
+  /// - A detected date test configuration file.
+  String buildBonesUITestConfig(
+      bool includeDartTestConfig, File dartTestConfigFile) {
+    String config = '''
+##
+## AUTO GENERATED:
+##   $bonesUiTestCliTitle
+##   ${DateTime.now()}
+##
+
+timeout: 60s  
+
+''';
+
+    if (includeDartTestConfig) {
+      var file = File(pack_path.join(bonesUICompileDir.path, 'dart_test.yaml'));
+      if (!file.existsSync()) {
+        dartTestConfigFile.copySync(file.path);
+      }
+
+      config += '\ninclude: dart_test.yaml\n';
+    } else {
+      config += '\nplatforms: [chrome]\n';
+    }
+
+    config += '\ncustom_html_template_path: $bonesUITestTemplateFileName\n';
+    return config;
+  }
+
+  void generateTestTemplateFile() {
+    var template = buildTestTemplateFile();
+    bonesUITestTemplateFile.writeAsStringSync(template);
+  }
+
+  String buildTestTemplateFile() {
+    var template = '''
+<!DOCTYPE html>
+<html>
+<head>
+  <title>{{testName}} - Bones_UI Test</title>
+  <meta charset="utf-8">
+  <link rel="stylesheet" href="../web/styles.css">
+  {{testScript}}
+  <script src="packages/test/dart.js"></script>
+</head>
+</html>
+''';
+    return template;
+  }
+}
+
+/// A Bones_UI project compiler.
+/// To run the UI tests the project must be compiled first.
+class BonesUIComiler {
+  /// The project directory. Default: [Directory.current]
+  final Directory projectDir;
+
+  /// The compilation directory. Defaylts to a random temporary directory (`dart_test_bones_ui_*`)
+  final Directory compileDir;
+
+  BonesUIComiler({Directory? projectDir, Directory? compileDir})
+      : projectDir = projectDir ?? Directory.current,
+        compileDir = compileDir ?? Directory(_createTempBonesUICompilerDir());
+
+  /// Prepares the compiler.
+  Future<void> prepare() async {
+    compileDir.createSync(recursive: true);
+  }
+
+  /// Compiles the project to [compileDir].
+  Future<bool> compile() async {
+    compileDir.create(recursive: true);
+
+    var compileDirPath = compileDir.path;
+
+    var projectPath = Directory.current.path;
+    print('\n** Compiling Bone_UI project: $projectPath');
+
+    print('-- BonesUI compile directory: $compileDirPath\n');
+
+    var buildArgs = ['run', 'build_runner', 'build', '-o', compileDirPath];
+
+    // dart run build_runner build -o /tmp/compileDir/
+    var exitCode =
+        await _runDartCommand(buildArgs, workingDirectory: projectPath);
+
+    if (exitCode != 0) {
+      throw StateError("Dart build error. Exit code: $exitCode");
+    }
+
+    linkWebDirToTestDir();
+
+    return true;
+  }
+
+  /// Links the content of the `web/` directory to the `test/` directory.
+  /// This is need to allow proper loading of resources,
+  /// since the browser runs the tests at the `test/` directory.
+  bool linkWebDirToTestDir() {
+    var webDir = Directory(pack_path.join(compileDir.path, 'web'));
+    if (!webDir.existsSync()) return false;
+
+    var testDir = Directory(pack_path.join(compileDir.path, 'test'));
+    if (!testDir.existsSync()) return false;
+
+    _linkDirectoryFiles(testDir, webDir);
+
+    return true;
+  }
+
+  void _linkDirectoryFiles(Directory linkDst, Directory targetDir) {
+    var list = targetDir.listSync();
+
+    print('** Linking directory content:');
+    print('  >> ${targetDir.path} -> ${linkDst.path}');
+
+    //var linkDstDirName = pack_path.basename(linkDst.path);
+
+    for (var e in list) {
+      var name = pack_path.basename(e.path);
+      if (name.isEmpty || name.startsWith('.')) {
+        continue;
+      }
+
+      var linkPath = pack_path.join(linkDst.path, name);
+
+      var linkFile = File(linkPath);
+
+      if (!linkFile.existsSync() &&
+          linkFile.statSync().type == FileSystemEntityType.notFound) {
+        var targetPath = e.path;
+
+        var link = Link(linkPath);
+        link.createSync(targetPath);
+        //print('  >> Linked: $linkDstDirName/$name -> $targetPath');
+      }
+    }
+  }
+
+  String? _dartExecutable;
+
+  FutureOr<String> get dartExecutable async =>
+      _dartExecutable ??= await _executablePath('dart');
+
+  Future<int> _runDartCommand(List<String> args,
+      {String? workingDirectory}) async {
+    var dartExecutable = await this.dartExecutable;
+
+    workingDirectory ??= Directory.current.path;
+
+    var process = await Process.start(dartExecutable, args,
+        workingDirectory: workingDirectory);
+
+    var outputDecoder = systemEncoding.decoder;
+
+    process.stdout.transform(outputDecoder).forEach((o) => stdout.write(o));
+    process.stderr.transform(outputDecoder).forEach((o) => stderr.write(o));
+
+    var exitCode = await process.exitCode;
+    return exitCode;
+  }
+
+  Future<String> _executablePath(String executableName,
+      {bool refresh = false}) async {
+    executableName = executableName.trim();
+
+    String? binPath;
+
+    if (!refresh) {
+      binPath = _whichExecutables[executableName];
+      if (binPath != null && binPath.isNotEmpty) {
+        return binPath;
+      }
+    }
+
+    binPath = await _whichExecutable(executableName);
+    binPath ??= '';
+
+    _whichExecutables[executableName] = binPath;
+
+    return binPath.isNotEmpty ? binPath : executableName;
+  }
+
+  Future<String?> _whichExecutable(String executableName) async {
+    var locator = Platform.isWindows ? 'where' : 'which';
+    var result = await Process.run(locator, [executableName]);
+
+    if (result.exitCode == 0) {
+      var binPath = '${result.stdout}'.trim();
+      return binPath;
+    } else {
+      return null;
+    }
+  }
+
+  void close() {
+    if (compileDir.existsSync()) {
+      compileDir.deleteSync(recursive: true);
+    }
+  }
+}
+
+/// The Bones_UI plugin:
+/// a [PlatformPlugin] based on a wrapped [BrowserPlatform] instance and a [BonesUIComiler].
+class BonesUIPlatform extends PlatformPlugin
+    implements CustomizablePlatform<ExecutableSettings> {
+  static Future<BrowserPlatform> _startBrowserPlatform(String root) async {
+    while (true) {
+      var platform = await BrowserPlatform.start(root: root);
+      var url = platform.url;
+      var urlPath = url.path.toLowerCase();
+
+      if (!urlPath.contains('%2f') && !urlPath.contains('%5c')) {
+        print('** `BrowserPlatform` start OK: $url');
+        return platform;
+      }
+
+      print('** `BrowserPlatform` URL has invalid characters: $url');
+      platform.close();
+
+      print('-- Retrying `BrowserPlatform.start`...');
+    }
+  }
+
+  /// Instantiates a [BonesUIPlatform].
+  static Future<BonesUIPlatform> create(BonesUIComiler bonesUIComiler,
+      {bool showUI = false}) async {
+    final compileDirPath = bonesUIComiler.compileDir.path;
+
+    if (compileDirPath.length < 5) {
+      throw StateError("Invalid compile directory: $compileDirPath");
+    }
+
+    var browserPlatform = await _startBrowserPlatform(compileDirPath);
+    return BonesUIPlatform(browserPlatform, bonesUIComiler, showUI: showUI);
+  }
+
+  /// The wrapped [BrowserPlatform] instance.
+  final BrowserPlatform browserPlatform;
+
+  /// The Bones_UI project compiler.
+  final BonesUIComiler bonesUIComiler;
+
+  /// If `true` runs the tests showing the UI in the browser.
+  final bool showUI;
+
+  BonesUIPlatform(this.browserPlatform, this.bonesUIComiler,
+      {this.showUI = false});
+
+  bool get headleass => !showUI;
+
+  Directory? prevWorkingDir;
+
+  @override
+  Future<RunnerSuite?> load(String path, SuitePlatform platform,
+      SuiteConfiguration suiteConfig, Map<String, Object?> message) async {
+    print('** Compiling test...');
+
+    prevWorkingDir = Directory.current;
+
+    var bonesUICompileDir = bonesUIComiler.compileDir;
+    Directory.current = bonesUICompileDir;
+
+    var runnerSuite =
+        await browserPlatform.load(path, platform, suiteConfig, message);
+
+    return runnerSuite;
+  }
+
+  @override
+  void customizePlatform(Runtime runtime, ExecutableSettings settings) =>
+      browserPlatform.customizePlatform(runtime, settings);
+
+  @override
+  ExecutableSettings mergePlatformSettings(
+          ExecutableSettings settings1, ExecutableSettings settings2) =>
+      browserPlatform.mergePlatformSettings(settings1, settings2);
+
+  @override
+  ExecutableSettings parsePlatformSettings(YamlMap settings) {
+    var map = Map.from(settings);
+    map['headless'] = headleass;
+
+    var settings2 = YamlMap.wrap(map);
+
+    return browserPlatform.parsePlatformSettings(settings2);
+  }
+
+  /// Closes this instance, the [bonesUIComiler] and the wrapped [browserPlatform].
+  @override
+  Future close() async {
+    if (prevWorkingDir != null) {
+      Directory.current = prevWorkingDir!;
+    }
+
+    bonesUIComiler.close();
+    await browserPlatform.close();
+
+    return super.close();
+  }
+}
+
+final Map<String, String> _whichExecutables = <String, String>{};
+
+String _createTempBonesUICompilerDir() => Directory(Directory.systemTemp.path)
+    .createTempSync('dart_test_bones_ui_')
+    .resolveSymbolicLinksSync();

--- a/lib/src/bones_ui_test_tools.dart
+++ b/lib/src/bones_ui_test_tools.dart
@@ -1,0 +1,242 @@
+import 'dart:html';
+
+import 'package:test/test.dart';
+
+import 'bones_ui.dart';
+import 'bones_ui_navigator.dart';
+import 'bones_ui_root.dart';
+
+const bonesUiTestToolTitle = 'Bones_UI/${BonesUI.version} - Test';
+
+/// Prints the Bones_UI Test Tool title.
+/// Used by [initializeTestUIRoot].
+void printTestToolTitle({
+  bool showUserAgent = true,
+}) {
+  var userAgent = window.navigator.userAgent;
+
+  var lines = [
+    bonesUiTestToolTitle,
+    if (showUserAgent) '» User Agent: $userAgent',
+    if (isHeadlessUI()) '» Headless',
+  ];
+
+  print(
+      '╔═════════════════════════════════════════════════════════════════════\n'
+      '${lines.map((l) => '║ $l\n').join()}'
+      '╚═════════════════════════════════════════════════════════════════════');
+}
+
+/// Returns `true` if the browser is running on `headless` mode.
+bool isHeadlessUI() {
+  var userAgent = window.navigator.userAgent;
+
+  if (userAgent.toLowerCase().contains('headless')) return true;
+
+  return false;
+}
+
+/// Initializes the test [UIRoot] using the [uiRootInstantiator] to instantiate it.
+Future<U> initializeTestUIRoot<U extends UIRoot>(
+    U Function(Element rootContainer) uiRootInstantiator,
+    {String outputDivID = 'test-output',
+    Duration initialRenderTimeout = const Duration(seconds: 5)}) async {
+  printTestToolTitle();
+
+  if (!isHeadlessUI()) {
+    slowUI();
+  }
+
+  print('** Starting test `UIRoot`...');
+
+  document.body!.appendHtml('<div id="$outputDivID"></div>');
+
+  var output = querySelector('#$outputDivID');
+  output!.children.clear();
+
+  // Reset the URL route/fragment.
+  // Usually the browser test plugin adds some parameters in the URL fragment.
+  {
+    var locationHref = window.location.href;
+    var locationUrl = Uri.parse(locationHref);
+    var fragment = locationUrl.fragment;
+
+    if (fragment.isNotEmpty) {
+      var locationUrlReset = fragment.isNotEmpty
+          ? locationUrl.removeFragment().toString()
+          : locationHref;
+
+      window.history.pushState({}, 'Test UIRoot: init', locationUrlReset);
+
+      print('-- Removed URL fragment> ${Uri.decodeFull(fragment)}');
+    }
+  }
+
+  var uiRoot = uiRootInstantiator(output);
+  print('-- Instantiated: $uiRoot');
+
+  uiRoot.initialize();
+
+  var ready = await uiRoot.isReady();
+  expect(ready, isTrue, reason: "`UIRoot` should be ready: $uiRoot");
+
+  print('-- Ready: $uiRoot');
+
+  UINavigator.navigateTo('');
+
+  print('-- Calling initial render...');
+  await uiRoot.callRenderAndWait(timeout: initialRenderTimeout);
+
+  print('-- Initialized: $uiRoot');
+
+  return uiRoot;
+}
+
+/// Expects [route] at [UINavigator.currentRoute].
+void expectUIRoute(String route, {String? reason, skip}) =>
+    expect(UINavigator.currentRoute, equals(route),
+        reason: reason ?? 'Expected route: `$route`', skip: skip);
+
+/// Expects [routeName] at [UINavigator.currentRoute].
+void expectUIRoutes(List<String> routes, {String? reason, skip}) {
+  if (routes.isEmpty) {
+    throw ArgumentError("Empty `routes`");
+  }
+
+  var currentRoute = UINavigator.currentRoute ?? '';
+
+  expect(routes.contains(currentRoute), isTrue,
+      reason: reason ?? 'Expected one of routes: $routes', skip: skip);
+}
+
+int _slowFactor = 1;
+
+/// Test UI sleep.
+Future<int> testUISleep({int? frames, int? ms}) =>
+    _testUISleepImpl(frames: frames, ms: ms);
+
+/// Unsafe version of [testUISleep].
+@Deprecated("Do not use this in production code!")
+Future<int> testUISleepUnsafe({int? frames, int? ms}) =>
+    _testUISleepImpl(frames: frames, ms: ms, maxMs: 9999999);
+
+Future<int> _testUISleepImpl({int? frames, int? ms, int maxMs = 10000}) {
+  ms = _sleepMs(ms, frames, maxMs);
+  print('** Test UI Sleep: $ms ms');
+  return Future.delayed(Duration(milliseconds: ms), () => ms!);
+}
+
+/// Test UI sleep until [ready]. Returns `bool` if [ready].
+/// - [timeoutMs] is the sleep timeout is ms.
+/// - [intervalMs] is the interval to check if it's [ready].
+/// - [minMs] is the minimal sleep time in ms.
+/// - [readyTitle] is the ready message to show in the log: `** Test UI Sleep Until $readyTitle`
+Future<bool> testUISleepUntil(bool Function() ready,
+    {String readyTitle = 'ready',
+    int? timeoutMs,
+    int? intervalMs,
+    int? minMs}) async {
+  timeoutMs = _sleepMs(timeoutMs ?? 1000, null, 9999999);
+
+  intervalMs = intervalMs != null
+      ? _sleepMs(intervalMs, null, 9999999)
+      : (timeoutMs ~/ 10).clamp(1, timeoutMs);
+
+  intervalMs = intervalMs.clamp(1, timeoutMs);
+
+  if (minMs != null) {
+    minMs = _sleepMs(minMs, null, 9999999);
+  }
+
+  print('** Test UI Sleep Until $readyTitle> sleep: $timeoutMs ms '
+      '(interval: $intervalMs ms${minMs != null ? ' ; min: $minMs ms' : ''})');
+
+  var initTime = DateTime.now();
+
+  while (true) {
+    if (ready()) {
+      var elapsedTime = DateTime.now().difference(initTime).inMilliseconds;
+      print(
+          '-- Test UI Sleep Until $readyTitle> READY (elapsedTime: $elapsedTime ms)');
+      return true;
+    }
+
+    var elapsedTime = DateTime.now().difference(initTime).inMilliseconds;
+
+    await Future.delayed(Duration(milliseconds: intervalMs));
+
+    if (elapsedTime >= timeoutMs) break;
+  }
+
+  var isReady = ready();
+
+  print(
+      '-- Test UI Sleep Until $readyTitle> ${isReady ? 'READY' : 'NOT READY'}');
+
+  if (minMs != null) {
+    var elapsedTime = DateTime.now().difference(initTime).inMilliseconds;
+    var remainingTime = timeoutMs - elapsedTime;
+
+    if (remainingTime > 0) {
+      print(
+          '-- Test UI Sleep Until $readyTitle> minimal sleep: $minMs ms (elapsed: $elapsedTime ms ; remaining: $remainingTime ms)');
+
+      await Future.delayed(Duration(milliseconds: remainingTime));
+    }
+  }
+
+  return ready();
+}
+
+int _sleepMs(int? ms, int? frames, int maxMs) {
+  ms ??= frames != null ? frames * 16 : 30;
+  ms = ms * _slowFactor;
+  ms.clamp(1, maxMs);
+  return ms;
+}
+
+/// Calls [testUISleepUntil] checking if [route] is the current route ([UINavigator.currentRoute]).
+Future<bool> testUISleepUntilRoute(String route,
+        {int? timeoutMs, int? intervalMs, int? minMs}) =>
+    testUISleepUntil(
+      () => UINavigator.currentRoute == route,
+      readyTitle: 'route `$route`',
+      timeoutMs: timeoutMs,
+      intervalMs: intervalMs,
+      minMs: minMs,
+    );
+
+/// Calls [testUISleepUntil] checking if [routes] has the current route ([UINavigator.currentRoute]).
+Future<bool> testUISleepUntilRoutes(List<String> routes,
+    {int? timeoutMs, int? intervalMs, int? minMs}) {
+  if (routes.isEmpty) {
+    throw ArgumentError("Empty `routes`");
+  }
+
+  return testUISleepUntil(
+    () => routes.contains(UINavigator.currentRoute ?? ''),
+    readyTitle: 'one of routes $routes',
+    timeoutMs: timeoutMs,
+    intervalMs: intervalMs,
+    minMs: minMs,
+  );
+}
+
+/// Slows the UI sleep by [slowFactor].
+///
+/// - This will be called by [initializeTestUIRoot] if [isHeadlessUI] is `true`.
+void slowUI({int slowFactor = 10}) {
+  _slowFactor = slowFactor.clamp(1, 100);
+  if (_slowFactor == 1) {
+    print('** Fast UI');
+  } else {
+    print('** Slow UI: $_slowFactor');
+  }
+}
+
+/// Resets the UI to fast mode (default).
+/// See [slowUI].
+void fastUI() {
+  _slowFactor = 1;
+  print('** Fast UI');
+}

--- a/lib/src/bones_ui_test_tools.dart
+++ b/lib/src/bones_ui_test_tools.dart
@@ -78,7 +78,8 @@ Future<U> initializeTestUIRoot<U extends UIRoot>(
   uiRoot.initialize();
 
   var ready = await uiRoot.isReady();
-  expect(ready, isTrue, reason: "`UIRoot` should be ready: $uiRoot");
+  expect(ready, anyOf(isTrue, isNull),
+      reason: "`UIRoot` should be ready: $uiRoot");
 
   print('-- Ready: $uiRoot');
 
@@ -109,7 +110,7 @@ void expectUIRoutes(List<String> routes, {String? reason, skip}) {
       reason: reason ?? 'Expected one of routes: $routes', skip: skip);
 }
 
-int _slowFactor = 1;
+double _speedFactor = 1;
 
 /// Test UI sleep.
 Future<int> testUISleep({int? frames, int? ms}) =>
@@ -136,7 +137,7 @@ Future<bool> testUISleepUntil(bool Function() ready,
     int? timeoutMs,
     int? intervalMs,
     int? minMs}) async {
-  timeoutMs = _sleepMs(timeoutMs ?? 1000, null, 9999999);
+  timeoutMs = _sleepMs(timeoutMs ?? 1000, null, 90000);
 
   intervalMs = intervalMs != null
       ? _sleepMs(intervalMs, null, 9999999)
@@ -146,6 +147,7 @@ Future<bool> testUISleepUntil(bool Function() ready,
 
   if (minMs != null) {
     minMs = _sleepMs(minMs, null, 9999999);
+    minMs = minMs.clamp(1, timeoutMs);
   }
 
   print('** Test UI Sleep Until $readyTitle> sleep: $timeoutMs ms '
@@ -190,7 +192,7 @@ Future<bool> testUISleepUntil(bool Function() ready,
 
 int _sleepMs(int? ms, int? frames, int maxMs) {
   ms ??= frames != null ? frames * 16 : 30;
-  ms = ms * _slowFactor;
+  ms = (ms * _speedFactor).toInt();
   ms.clamp(1, maxMs);
   return ms;
 }
@@ -226,17 +228,17 @@ Future<bool> testUISleepUntilRoutes(List<String> routes,
 ///
 /// - This will be called by [initializeTestUIRoot] if [isHeadlessUI] is `true`.
 void slowUI({int slowFactor = 10}) {
-  _slowFactor = slowFactor.clamp(1, 100);
-  if (_slowFactor == 1) {
+  _speedFactor = slowFactor.clamp(1, 100).toDouble();
+  if (_speedFactor == 1) {
     print('** Fast UI');
   } else {
-    print('** Slow UI: $_slowFactor');
+    print('** Slow UI: $_speedFactor');
   }
 }
 
-/// Resets the UI to fast mode (default).
+/// Sets the UI to fast mode (default).
 /// See [slowUI].
-void fastUI() {
-  _slowFactor = 1;
+void fastUI({double fastFactor = 1}) {
+  _speedFactor = fastFactor.clamp(0.0001, 1);
   print('** Fast UI');
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,8 +31,8 @@ dependencies:
   extended_type: ^2.0.1
   logging: ^1.1.0
   test: ^1.22.0
-  test_api: 0.4.17
-  test_core: 0.4.21
+  test_api: ^0.4.17
+  test_core: ^0.4.21
   path: ^1.8.3
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bones_ui
 description: Bones_UI - Simple and easy Web User Interface Framework for Dart
-version: 2.0.27
+version: 2.1.0
 homepage: https://github.com/Colossus-Services/bones_ui
 
 environment:
@@ -14,8 +14,8 @@ dependencies:
   swiss_knife: ^3.1.2
   dynamic_call: ^2.0.1
   mercury_client: ^2.1.7
-  intl_messages: ^2.0.3
-  dom_tools: ^2.1.7
+  intl_messages: ^2.0.4
+  dom_tools: ^2.1.8
   dom_builder: ^2.1.2
   json_render: ^2.0.4
   json_object_mapper: ^2.0.0
@@ -23,21 +23,24 @@ dependencies:
   intl: ^0.17.0
   enum_to_string: ^2.0.1
   yaml: ^3.1.1
-  archive: ^3.3.4
+  archive: ^3.3.5
   collection: ^1.17.0
   args: ^2.3.1
   project_template: ^1.0.2
   resource_portable: ^3.0.0
   extended_type: ^2.0.1
   logging: ^1.1.0
+  test: ^1.22.0
+  test_api: 0.4.17
+  test_core: 0.4.21
+  path: ^1.8.3
 
 dev_dependencies:
   build_web_compilers: ^3.2.7
   build_runner: ^2.3.2
   lints: ^2.0.1
   dependency_validator: ^3.2.2
-  test: ^1.22.0
-  path: ^1.8.2
+
 
 #dependency_overrides:
 #  swiss_knife:

--- a/test/bones_ui_test.dart
+++ b/test/bones_ui_test.dart
@@ -3,7 +3,7 @@ import 'package:bones_ui/bones_ui_test.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('Components', () {
+  group('UIRoot', () {
     late final MyRoot uiRoot;
 
     setUpAll(() async {

--- a/test/bones_ui_test.dart
+++ b/test/bones_ui_test.dart
@@ -1,23 +1,21 @@
 @TestOn('browser')
-import 'dart:html';
-
-import 'package:bones_ui/bones_ui.dart';
+import 'package:bones_ui/bones_ui_test.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('Components', () {
-    final rootContainer = DivElement();
-    late final MyRoot root;
+    late final MyRoot uiRoot;
 
-    setUpAll(() {
-      root = MyRoot(rootContainer);
+    setUpAll(() async {
+      uiRoot =
+          await initializeTestUIRoot((rootContainer) => MyRoot(rootContainer));
     });
 
-    test('initialize', () async {
-      root.initialize();
-      await root.onFinishRender.first;
+    test('basic', () async {
+      await uiRoot.callRenderAndWait();
+      await testUISleep(ms: 100);
 
-      var myHome = rootContainer.querySelector('#my-home');
+      var myHome = uiRoot.querySelector('#my-home');
       expect(myHome, isA<DivElement>());
 
       expect(myHome?.text, contains('Hello world'));


### PR DESCRIPTION
- `bones_ui` CLI:
  - Added `test` command, for Bones_UI unit tests.
- Added libraries:
  - `bones_ui_test` to import the Bones_UI Test tools.
  - `bones_ui_test_clit` to import the Bones_UI Test CLI (used by `test` command).
- `UIComponent`
  - Added `waiteRender`, `callRenderAndWait`, `querySelector`, `querySelectorAll`. - These methods can be useful in unit tests.
- `ElementExtension`:
- Fix `UINavigator` behavior when `findNavigable` can't find a `UINavigableComponent` for the route.
- intl_messages: ^2.0.4
- dom_tools: ^2.1.8
- archive: ^3.3.5
- test: ^1.22.0
- test_api: 0.4.17
- test_core: 0.4.21
- path: ^1.8.3