### PR TITLE
v2.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 2.5.5
+
+- New `UIRootComponent`:
+  - Implemented by `UIRoot` and `UIDialogBase`
+
+- `UIComponent`:
+  - Extends `UIRootComponent`.
+  - Added getter `uiRootComponent`.
+  - Added `renderingUIComponent`: returns the current rendering component in the stack,
+  - Added `parentRenderingUIComponent`: can resolve asynchronous parent renderer.
+  - `_construct`: improved parent `UIComponent` resolution.
+
+- `UIDialogBase` extends `UIRootComponent`:
+  - `getRenderedUIComponentById`, `getRenderedUIComponents`: fix resolution of child `UIComponent`s. 
+
+- archive: ^3.5.1
+- args: ^2.5.0
+- test: ^1.25.5
+- test_core: ^0.6.2
+
 ## 2.5.4
 
 - New `UIComponentDOMContext`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `InputConfig`:
   - Added field `labelVerticalAlign`
 
+- dom_builder: ^2.2.3
 - archive: ^3.5.1
 - args: ^2.5.0
 - test: ^1.25.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,15 @@
   - Added `renderingUIComponent`: returns the current rendering component in the stack,
   - Added `parentRenderingUIComponent`: can resolve asynchronous parent renderer.
   - `_construct`: improved parent `UIComponent` resolution.
+  - `resolveTextIntl`: improve resolution of `uiRoot` and call to `intlMessageResolver`.
 
 - `UIDialogBase` extends `UIRootComponent`:
   - `getRenderedUIComponentById`, `getRenderedUIComponents`: fix resolution of child `UIComponent`s. 
+
+- `UIInputTable`:
+  - Added field `scrollToInvalidElement`.
+- `InputConfig`:
+  - Added field `labelVerticalAlign`
 
 - archive: ^3.5.1
 - args: ^2.5.0

--- a/lib/src/bones_ui.dart
+++ b/lib/src/bones_ui.dart
@@ -1,3 +1,3 @@
 class BonesUI {
-  static const String version = '2.5.4';
+  static const String version = '2.5.5';
 }

--- a/lib/src/bones_ui_component.dart
+++ b/lib/src/bones_ui_component.dart
@@ -550,6 +550,8 @@ abstract class UIComponent extends UIEventHandler {
   /// Resolves [text] `{{intl:key}}` messages.
   String resolveTextIntl(String text) {
     if (text.contains('{{')) {
+      var uiRoot = this.uiRoot ?? UIRoot.getInstance();
+
       var intlMessageResolver = uiRoot?.intlMessageResolver;
       intlMessageResolver ??=
           (String key, [Map<String, dynamic>? parameters]) => key;

--- a/lib/src/bones_ui_navigator.dart
+++ b/lib/src/bones_ui_navigator.dart
@@ -939,7 +939,8 @@ abstract class UINavigableContent extends UINavigableComponent {
       super.style,
       super.style2,
       super.inline,
-      super.renderOnConstruction});
+      super.renderOnConstruction,
+      super.id});
 
   @override
   dynamic render() {

--- a/lib/src/bones_ui_root.dart
+++ b/lib/src/bones_ui_root.dart
@@ -123,6 +123,7 @@ abstract class UIRoot extends UIRootComponent {
       {this.name,
       dynamic style,
       dynamic classes,
+      super.id,
       UIComponentClearParent super.clearParent =
           UIComponentClearParent.onInitialRender,
       this.readyTimeout = const Duration(seconds: 15)})

--- a/lib/src/bones_ui_root.dart
+++ b/lib/src/bones_ui_root.dart
@@ -20,91 +20,39 @@ import 'component/loading.dart';
 import 'component/multi_selection.dart';
 import 'component/svg.dart';
 
-/// The root for `Bones_UI` component tree.
-abstract class UIRoot extends UIComponent {
-  static UIRoot? _rootInstance;
-
-  /// Returns the current [UIRoot] instance.
-  static UIRoot? getInstance() {
-    return _rootInstance;
-  }
+/// Base class for [UIComponent]s serving as roots for other components.
+/// - Implemented by [UIRoot] and [UIDialogBase].
+/// - Handles registration of the tree of [UIComponent]s and sub-[UIComponent]s.
+abstract class UIRootComponent extends UIComponent {
+  UIRootComponent(super.parent,
+      {super.componentClass,
+      super.componentStyle,
+      super.classes,
+      super.classes2,
+      super.style,
+      super.style2,
+      super.clearParent,
+      super.inline,
+      super.construct,
+      super.renderOnConstruction,
+      super.preserveRender,
+      super.id,
+      super.generator});
 
   late DOMTreeReferenceMap<UIComponent> _uiComponentsTree;
 
-  LocalesManager? _localesManager;
-
-  Future<bool>? _futureInitializeLocale;
-
-  Duration readyTimeout;
-
-  final String? name;
-
-  UIRoot(super.rootContainer,
-      {this.name,
-      dynamic style,
-      dynamic classes,
-      UIComponentClearParent super.clearParent =
-          UIComponentClearParent.onInitialRender,
-      this.readyTimeout = const Duration(seconds: 15)})
-      : super(
-            style: style,
-            classes: classes,
-            componentClass: 'ui-root',
-            construct: false) {
-    _initializeAll();
-
-    final componentInternals = this.componentInternals;
-
-    if (componentInternals.getContent() == null) {
-      componentInternals.setContent(createContentElement(true));
-    }
-
+  void initializeUIComponentsTree() {
     _uiComponentsTree = DOMTreeReferenceMap(content!,
         keepPurgedKeys: true,
         maxPurgedEntries: 1000,
         purgedEntriesTimeout: Duration(minutes: 1));
-
-    _rootInstance = this;
-
-    componentInternals.construct(
-        false, true, classes, null, 'ui-root', style, null, null, false);
-
-    _localesManager =
-        createLocalesManager(_callInitializeLocale, _onDefineLocale);
-    _localesManager!.onPreDefineLocale.add(onPreDefineLocale);
-
-    _futureInitializeLocale = _localesManager!.initialize(getPreferredLocale);
-
-    window.onResize.listen(_onResize);
-
-    UIConsole.checkAutoEnable();
   }
-
-  /// Returns `true` if this instance is running from `bones_ui test` CLI.
-  bool get isTest => content?.classes.contains('__bones_ui_test__') ?? false;
 
   @override
   void registerInUIRoot() {}
 
-  /// Returns this [UIRoot] instance.
   @override
-  UIRoot get uiRoot => this;
-
-  /// The default loading to render for all [UIComponent] that do not implement [UIComponent.renderLoading].
-  @override
-  dynamic renderLoading() => null;
-
-  IntlMessageResolver? _intlMessageResolver;
-
-  IntlMessageResolver? get intlMessageResolver => _intlMessageResolver;
-
-  set intlMessageResolver(dynamic resolver) {
-    if (resolver is IntlMessages) {
-      _intlMessageResolver = resolver.buildMsg;
-    } else {
-      _intlMessageResolver = toIntlMessageResolver(resolver);
-    }
-  }
+  UIRootComponent get uiRootComponent;
 
   bool get isAnyComponentRendering => _uiComponentsTree.validEntries
       .where((e) => e.value.isRendering)
@@ -142,6 +90,99 @@ abstract class UIRoot extends UIComponent {
   }
 
   void purgeUIComponentsTree() => _uiComponentsTree.purge();
+
+  /// [EventStream] for when this [UIRoot] finishes to render UI.
+  final EventStream<UIRootComponent> onFinishRender = EventStream();
+
+  void notifyFinishRender() {
+    onFinishRender.add(this);
+
+    _uiComponentsTree.purge();
+    //print('FINISH RENDER> _uiComponentsTree: $_uiComponentsTree');
+  }
+}
+
+/// The root for `Bones_UI` component tree.
+abstract class UIRoot extends UIRootComponent {
+  static UIRoot? _rootInstance;
+
+  /// Returns the current [UIRoot] instance.
+  static UIRoot? getInstance() {
+    return _rootInstance;
+  }
+
+  LocalesManager? _localesManager;
+
+  Future<bool>? _futureInitializeLocale;
+
+  Duration readyTimeout;
+
+  final String? name;
+
+  UIRoot(super.rootContainer,
+      {this.name,
+      dynamic style,
+      dynamic classes,
+      UIComponentClearParent super.clearParent =
+          UIComponentClearParent.onInitialRender,
+      this.readyTimeout = const Duration(seconds: 15)})
+      : super(
+            style: style,
+            classes: classes,
+            componentClass: 'ui-root',
+            construct: false) {
+    _initializeAll();
+
+    final componentInternals = this.componentInternals;
+
+    if (componentInternals.getContent() == null) {
+      componentInternals.setContent(createContentElement(true));
+    }
+
+    initializeUIComponentsTree();
+
+    _rootInstance = this;
+
+    componentInternals.construct(
+        false, true, classes, null, 'ui-root', style, null, null, false);
+
+    _localesManager =
+        createLocalesManager(_callInitializeLocale, _onDefineLocale);
+    _localesManager!.onPreDefineLocale.add(onPreDefineLocale);
+
+    _futureInitializeLocale = _localesManager!.initialize(getPreferredLocale);
+
+    window.onResize.listen(_onResize);
+
+    UIConsole.checkAutoEnable();
+  }
+
+  /// Returns `true` if this instance is running from `bones_ui test` CLI.
+  bool get isTest => content?.classes.contains('__bones_ui_test__') ?? false;
+
+  /// Returns this [UIRoot] instance.
+  @override
+  UIRoot get uiRoot => this;
+
+  /// Returns this [UIRoot] instance.
+  @override
+  UIRootComponent get uiRootComponent => this;
+
+  /// The default loading to render for all [UIComponent] that do not implement [UIComponent.renderLoading].
+  @override
+  dynamic renderLoading() => null;
+
+  IntlMessageResolver? _intlMessageResolver;
+
+  IntlMessageResolver? get intlMessageResolver => _intlMessageResolver;
+
+  set intlMessageResolver(dynamic resolver) {
+    if (resolver is IntlMessages) {
+      _intlMessageResolver = resolver.buildMsg;
+    } else {
+      _intlMessageResolver = toIntlMessageResolver(resolver);
+    }
+  }
 
   @override
   void onPreConstruct() {
@@ -263,16 +304,6 @@ abstract class UIRoot extends UIComponent {
 
   /// [EventStream] for when this [UIRoot] is initialized.
   final EventStream<UIRoot> onInitialize = EventStream();
-
-  /// [EventStream] for when this [UIRoot] finishes to render UI.
-  final EventStream<UIRoot> onFinishRender = EventStream();
-
-  void notifyFinishRender() {
-    onFinishRender.add(this);
-
-    _uiComponentsTree.purge();
-    //print('FINISH RENDER> _uiComponentsTree: $_uiComponentsTree');
-  }
 
   void _onReadyToInitialize() {
     UIConsole.log('UIRoot> ready to initialize!');

--- a/lib/src/bones_ui_root.dart
+++ b/lib/src/bones_ui_root.dart
@@ -372,7 +372,7 @@ abstract class UIRoot extends UIRootComponent {
 
   /// Returns `true` if this [UIRoot] is closed.
   ///
-  /// - Seee [close] and [closeOperations].
+  /// - See [close] and [closeOperations].
   bool get isClosed => _closed;
 
   FutureOr<bool> close({bool refreshAfterClose = true}) {
@@ -386,6 +386,7 @@ abstract class UIRoot extends UIRootComponent {
         if (refreshAfterClose) {
           refresh(forceRender: true);
         }
+        UIConsole.log('UIRoot> closed!');
         onClose.add(this);
         return true;
       });
@@ -393,6 +394,7 @@ abstract class UIRoot extends UIRootComponent {
       if (refreshAfterClose) {
         refresh(forceRender: true);
       }
+      UIConsole.log('UIRoot> closed!');
       onClose.add(this);
       return true;
     }

--- a/lib/src/bones_ui_test_tools.dart
+++ b/lib/src/bones_ui_test_tools.dart
@@ -506,7 +506,7 @@ void _testUIImpl<U extends UIRoot>(
       context.setTestWindowTitle('tearDown');
 
       if (uiRoot != null) {
-        uiRoot!.close();
+        await uiRoot!.close();
         await testUISleep(ms: 100);
       }
 
@@ -573,13 +573,13 @@ void _testUIImpl<U extends UIRoot>(
     body(context);
 
     test('close', () async {
-      context.setTestWindowTitle('tearDown');
+      context.setTestWindowTitle('close');
 
       if (uiRoot != null) {
         await uiRoot!.callRenderAndWait();
         await testUISleep(ms: 100);
 
-        uiRoot!.close();
+        await uiRoot!.close();
 
         expect(uiRoot!.isClosed, isTrue);
 

--- a/lib/src/component/dialog.dart
+++ b/lib/src/component/dialog.dart
@@ -11,7 +11,7 @@ import '../bones_ui_root.dart';
 import 'loading.dart';
 
 /// Component that renders a dialog.
-abstract class UIDialogBase extends UIComponent {
+abstract class UIDialogBase extends UIRootComponent {
   static final rootParent = document.body;
 
   final bool hideUIRoot;
@@ -45,7 +45,15 @@ abstract class UIDialogBase extends UIComponent {
           componentClass: 'ui-dialog',
         ) {
     _myConfigure(style);
+
+    initializeUIComponentsTree();
   }
+
+  @override
+  UIRoot? get uiRoot => null;
+
+  @override
+  UIRootComponent get uiRootComponent => this;
 
   void _myConfigure(dynamic style) {
     content!.style

--- a/lib/src/component/input_config.dart
+++ b/lib/src/component/input_config.dart
@@ -54,6 +54,7 @@ class InputConfig {
   List<String> classes;
 
   String? labelStyle;
+  String? labelVerticalAlign;
 
   String? style;
 
@@ -77,6 +78,8 @@ class InputConfig {
       var attributes = findKeyValue(config, ['attributes'], true);
       var classes = findKeyValue(config, ['class', 'classes'], true);
       var labelStyle = findKeyValue(config, ['labelStyle'], true);
+      var labelVerticalAlign =
+          findKeyValue(config, ['labelVerticalAlign'], true);
       var style = findKeyValue(config, ['style'], true);
       var options = findKeyValue(config, ['options'], true);
       var optional = parseBool(findKeyValue(config, ['optional'], true), false);
@@ -98,6 +101,7 @@ class InputConfig {
           optional: optional,
           classes: classes,
           labelStyle: labelStyle,
+          labelVerticalAlign: labelVerticalAlign,
           style: style);
     }
 
@@ -116,6 +120,7 @@ class InputConfig {
     bool? optional = false,
     Object? classes,
     String? labelStyle,
+    String? labelVerticalAlign,
     String? style,
     FieldInputRender? inputRender,
     FieldValueProvider? valueProvider,
@@ -151,15 +156,15 @@ class InputConfig {
 
     _label = label;
 
-    if (labelStyle != null) {
-      labelStyle = labelStyle.trim();
-      this.labelStyle = labelStyle.isNotEmpty ? labelStyle : null;
-    }
+    this.labelStyle = _normalizeNotEmpty(labelStyle);
+    this.labelVerticalAlign = _normalizeNotEmpty(labelVerticalAlign);
+    this.style = _normalizeNotEmpty(style);
+  }
 
-    if (style != null) {
-      style = style.trim();
-      this.style = style.isNotEmpty ? style : null;
-    }
+  static String? _normalizeNotEmpty(String? s) {
+    if (s == null) return null;
+    s = s.trim();
+    return s.isNotEmpty ? s : null;
   }
 
   String get id => _id;
@@ -477,6 +482,8 @@ class UIInputTable extends UIComponent {
   final String? inputErrorClass;
   final String? invalidValueClass;
 
+  final bool scrollToInvalidElement;
+
   UIInputTable(super.parent, this._inputs,
       {List? extraRows,
       this.actionListenerComponent,
@@ -486,6 +493,7 @@ class UIInputTable extends UIComponent {
       this.invalidValueClass,
       this.showLabels = true,
       this.showInvalidMessages = true,
+      this.scrollToInvalidElement = true,
       super.classes,
       super.style,
       dynamic tableClasses,
@@ -594,7 +602,7 @@ class UIInputTable extends UIComponent {
 
         if (ok) {
           var element = getFieldElement(fieldName);
-          if (element != null) {
+          if (element != null && scrollToInvalidElement) {
             scrollToElement(element);
           }
         }
@@ -626,9 +634,11 @@ class UIInputTable extends UIComponent {
   @override
   dynamic render() {
     var form = FormElement();
+    form.style.width = '100%';
     form.autocomplete = 'off';
 
     var table = TableElement();
+    table.style.width = '100%';
 
     if (_tableClasses.isNotEmpty) {
       table.classes.addAll(_tableClasses);
@@ -646,8 +656,13 @@ class UIInputTable extends UIComponent {
       if (showLabels) {
         var label = input.label ?? '';
 
+        var verticalAlign = input.labelVerticalAlign?.trim();
+        if (verticalAlign == null || verticalAlign.isEmpty) {
+          verticalAlign = 'top';
+        }
+
         var cell = row.addCell()
-          ..style.verticalAlign = 'top'
+          ..style.verticalAlign = verticalAlign
           ..style.textAlign = 'right';
 
         var labelStyle = input.labelStyle;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ executables:
 dependencies:
   intl_messages: ^2.3.0
   dom_tools: ^2.3.0
-  dom_builder: ^2.2.2
+  dom_builder: ^2.2.3
   json_render: ^2.1.0
   json_object_mapper: ^2.0.1
   swiss_knife: ^3.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bones_ui
 description: Bones_UI - An intuitive and user-friendly Web User Interface framework for Dart.
-version: 2.5.4
+version: 2.5.5
 homepage: https://github.com/Colossus-Services/bones_ui
 
 environment:
@@ -28,14 +28,14 @@ dependencies:
   intl: ^0.19.0
   enum_to_string: ^2.0.1
   yaml: ^3.1.2
-  archive: ^3.4.10
+  archive: ^3.5.1
   collection: ^1.18.0
-  args: ^2.4.2
+  args: ^2.5.0
   logging: ^1.2.0
   path: ^1.9.0
-  test: ^1.25.3
+  test: ^1.25.5
   test_api: ^0.7.1
-  test_core: ^0.6.1
+  test_core: ^0.6.2
   stream_channel: ^2.1.2
   stack_trace: ^1.11.1
 

--- a/test/bones_ui_test.dart
+++ b/test/bones_ui_test.dart
@@ -23,6 +23,9 @@ void main() {
 
       expect(myHome?.text, contains('Hello world'));
 
+      expect(myHome?.text, contains('- uiRoot: MyRoot'));
+      expect(myHome?.text, contains('- uiRootComponent: MyRoot'));
+
       var btn1 = uiRoot.selectExpected<web.ButtonElement>('*');
       expect(btn1, isA<web.ButtonElement>());
       expect(btn1.text, equals('Go to: contact'));
@@ -34,7 +37,9 @@ void main() {
       expect(uiRoot.querySelector('#my-contact'), isNotNull);
 
       var myContact1 = uiRoot.querySelector<web.DivElement>('#my-contact');
-      expect(myContact1!.text, isNot(contains('foo@mail.com')));
+
+      expect(myContact1!.text, contains('Loading...'));
+      expect(myContact1.text, isNot(contains('foo@mail.com')));
 
       expect(isComponentInDOM(myContact1), isTrue);
       expect(canBeInDOM(myContact1), isTrue);
@@ -50,6 +55,9 @@ void main() {
 
       expect(myContact2?.text, contains('foo@mail.com'));
       expect(isComponentInDOM(myContact1), isTrue);
+
+      expect(myContact1.text, contains('* uiRoot: MyRoot'));
+      expect(myContact1.text, contains('* uiRootComponent: MyRoot'));
 
       var uiContact2 = uiRoot.getUIComponentByContent(myContact2);
       expect(uiContact2, isA<MyContact>());
@@ -76,7 +84,7 @@ void main() {
 }
 
 class MyRoot extends UIRoot {
-  MyRoot(super.rootContainer);
+  MyRoot(super.rootContainer) : super(id: 'MyRoot');
 
   late final _myContent = MyContent(this);
 
@@ -85,7 +93,8 @@ class MyRoot extends UIRoot {
 }
 
 class MyContent extends UINavigableContent {
-  MyContent(Object? parent) : super(parent, ['home', 'contact']);
+  MyContent(Object? parent)
+      : super(parent, ['home', 'contact'], id: 'MyContent');
 
   @override
   renderRoute(String? route, Map<String, String>? parameters) {
@@ -103,12 +112,20 @@ class MyHome extends UIComponent {
   MyHome(super.parent) : super(id: 'my-home');
 
   @override
-  render() =>
-      '<h1>Home</h1><p>Hello world!<br><hr><button navigate="contact">Go to: contact</button>';
+  render() => '<h1>Home</h1>'
+      '<p>Hello world!<br>'
+      '<hr>'
+      '- uiRoot: ${uiRoot?.id} <br>'
+      '- uiRootComponent: ${uiRootComponent?.id} '
+      '<hr>'
+      '<button navigate="contact">Go to: contact</button>';
 }
 
 class MyContact extends UIComponent {
   MyContact(super.parent) : super(id: 'my-contact');
+
+  @override
+  renderLoading() => 'Loading...';
 
   @override
   render() {
@@ -119,6 +136,9 @@ class MyContact extends UIComponent {
         $tag('h1', content: 'Contact'),
         $p(),
         $span(content: 'foo@mail.com'),
+        $hr(),
+        $div(content: ['* uiRoot: ', uiRoot?.id]),
+        $div(content: ['* uiRootComponent: ', uiRootComponent?.id]),
         $hr(),
         $button(attributes: {'navigate': 'home'}, content: 'Go to: home'),
       ]);


### PR DESCRIPTION
- New `UIRootComponent`:
  - Implemented by `UIRoot` and `UIDialogBase`

- `UIComponent`:
  - Extends `UIRootComponent`.
  - Added getter `uiRootComponent`.
  - Added `renderingUIComponent`: returns the current rendering component in the stack,
  - Added `parentRenderingUIComponent`: can resolve asynchronous parent renderer.
  - `_construct`: improved parent `UIComponent` resolution.

- `UIDialogBase` extends `UIRootComponent`:
  - `getRenderedUIComponentById`, `getRenderedUIComponents`: fix resolution of child `UIComponent`s.

- archive: ^3.5.1
- args: ^2.5.0
- test: ^1.25.5
- test_core: ^0.6.2