### PR TITLE
v2.5.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2.5.9
+
+- `UIRootComponent`:
+  - Constructor:
+    - register at `_rootComponentInstances`, using `WeakReference`.
+  - Added `getInstances`.
+
+- `UIComponent`:
+  - `_getUIComponentByContent`, `_getUIComponentByChild`:
+    - Search first through `UIRoot.getInstance()` and also through `UIRootComponent.getInstances()`.
+
 ## 2.5.8
 
 - sdk: '>=3.4.0 <4.0.0'

--- a/lib/src/bones_ui.dart
+++ b/lib/src/bones_ui.dart
@@ -1,3 +1,3 @@
 class BonesUI {
-  static const String version = '2.5.8';
+  static const String version = '2.5.9';
 }

--- a/lib/src/bones_ui_component.dart
+++ b/lib/src/bones_ui_component.dart
@@ -1004,12 +1004,35 @@ abstract class UIComponent extends UIEventHandler {
 
   static UIComponent? _getUIComponentByContent(UIElement? content) {
     if (content == null) return null;
-    return UIRoot.getInstance()?.getUIComponentByContent(content);
+    return _getUIComponent((o) => o.getUIComponentByContent(content));
   }
 
   static UIComponent? _getUIComponentByChild(UIElement? content) {
     if (content == null) return null;
-    return UIRoot.getInstance()?.getUIComponentByChild(content);
+    return _getUIComponent((o) => o.getUIComponentByChild(content));
+  }
+
+  static UIComponent? _getUIComponent(
+      UIComponent? Function(UIRootComponent uiRootComponent) caller) {
+    var uiRoot = UIRoot.getInstance();
+
+    var uiComponent = uiRoot == null ? null : caller(uiRoot);
+    if (uiComponent != null) {
+      return uiComponent;
+    }
+
+    if (uiComponent == null) {
+      for (var uiRootComponent in UIRootComponent.getInstances()) {
+        if (uiRootComponent == uiRoot) continue;
+
+        uiComponent = caller(uiRootComponent);
+        if (uiComponent != null) {
+          return uiComponent;
+        }
+      }
+    }
+
+    return null;
   }
 
   UIComponent? findUIComponentByID(String id) {

--- a/lib/src/bones_ui_root.dart
+++ b/lib/src/bones_ui_root.dart
@@ -24,6 +24,34 @@ import 'component/svg.dart';
 /// - Implemented by [UIRoot] and [UIDialogBase].
 /// - Handles registration of the tree of [UIComponent]s and sub-[UIComponent]s.
 abstract class UIRootComponent extends UIComponent {
+  static final List<WeakReference<UIRootComponent>> _rootComponentInstances =
+      [];
+
+  /// Returns the current [UIRootComponent] instances.
+  static List<UIRootComponent> getInstances() {
+    var instances = <UIRootComponent>[];
+
+    List<WeakReference<Object>>? del;
+
+    for (var ref in _rootComponentInstances) {
+      var o = ref.target;
+      if (o != null) {
+        instances.add(o);
+      } else {
+        del ??= [];
+        del.add(ref);
+      }
+    }
+
+    if (del != null) {
+      for (var ref in del) {
+        _rootComponentInstances.remove(ref);
+      }
+    }
+
+    return instances;
+  }
+
   UIRootComponent(super.parent,
       {super.componentClass,
       super.componentStyle,
@@ -37,7 +65,9 @@ abstract class UIRootComponent extends UIComponent {
       super.renderOnConstruction,
       super.preserveRender,
       super.id,
-      super.generator});
+      super.generator}) {
+    _rootComponentInstances.add(WeakReference(this));
+  }
 
   late DOMTreeReferenceMap<UIComponent> _uiComponentsTree;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bones_ui
 description: Bones_UI - An intuitive and user-friendly Web User Interface framework for Dart.
-version: 2.5.8
+version: 2.5.9
 homepage: https://github.com/Colossus-Services/bones_ui
 
 environment:


### PR DESCRIPTION
- `UIRootComponent`:
  - Constructor: - register at `_rootComponentInstances`, using `WeakReference`.
  - Added `getInstances`.

- `UIComponent`:
  - `_getUIComponentByContent`, `_getUIComponentByChild`: - Search first through `UIRoot.getInstance()` and also through `UIRootComponent.getInstances()`.