### PR TITLE
v3.0.2 - UIComponent.subComponent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 3.0.2
+
+- `UIComponent`:
+  - Added private `_subComponent` flag to distinguish subcomponents.
+  - Refactored constructors:
+    - Added private named constructor `UIComponent._` to centralize initialization.
+    - Added public mirror constructor `UIComponent` with detailed documentation on parameters controlling rendering, styling, and structure.
+    - Added new constructor `UIComponent.subComponent` for creating components attached to an existing `parentComponent`, sharing its DOM mapping context.
+  - Updated `dispose` method to avoid disposing shared `domTreeMap` when the component is a subcomponent.
+
+- `UIButton` (`button.dart`):
+  - Extended `$uiButtonLoader` function to support additional attributes for loaded text styling and content:
+    - Added parameters: `loadedTextClass`, `loadedTextStyle`, `loadedTextErrorClass`, `loadedTextErrorStyle`, `loadedTextOK`, `loadedTextError`.
+    - Added corresponding attributes to the returned DOM element for these new parameters.
+
 ## 3.0.1
 
 - `UIComponent`:

--- a/lib/src/bones_ui.dart
+++ b/lib/src/bones_ui.dart
@@ -1,3 +1,3 @@
 class BonesUI {
-  static const String version = '3.0.1';
+  static const String version = '3.0.2';
 }

--- a/lib/src/component/button.dart
+++ b/lib/src/component/button.dart
@@ -276,6 +276,12 @@ DOMElement $uiButtonLoader(
     Map<String, String>? attributes,
     content,
     bool commented = false,
+    loadedTextClass,
+    loadedTextStyle,
+    loadedTextErrorClass,
+    loadedTextErrorStyle,
+    loadedTextOK,
+    loadedTextError,
     bool? withProgress,
     dynamic loadingConfig}) {
   return $tag(
@@ -290,6 +296,18 @@ DOMElement $uiButtonLoader(
             parseStringFromInlineList(buttonClasses)?.join(',') ?? '',
       if (buttonClasses != null) 'button-style': CSS(buttonStyle).style,
       if (withProgress != null) 'with-progress': '$withProgress',
+      if (loadedTextStyle != null)
+        'loaded-text-style': CSS(loadedTextStyle).style,
+      if (loadedTextClass != null)
+        'loaded-text-classes':
+            parseStringFromInlineList(buttonClasses)?.join(',') ?? '',
+      if (loadedTextErrorStyle != null)
+        'loaded-text-error-style': CSS(loadedTextErrorStyle).style,
+      if (loadedTextErrorClass != null)
+        'loaded-text-error-classes':
+            parseStringFromInlineList(loadedTextErrorClass)?.join(',') ?? '',
+      if (loadedTextOK != null) 'loaded-text-ok': '$loadedTextOK',
+      if (loadedTextError != null) 'loaded-text-error': '$loadedTextError',
       if (loadingConfig != null)
         'loading-config': (loadingConfig is UILoadingConfig
             ? loadingConfig.toInlineProperties()

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bones_ui
 description: Bones_UI - An intuitive and user-friendly Web User Interface framework for Dart.
-version: 3.0.1
+version: 3.0.2
 homepage: https://github.com/Colossus-Services/bones_ui
 
 environment:


### PR DESCRIPTION
- `UIComponent`:
  - Added private `_subComponent` flag to distinguish subcomponents.
  - Refactored constructors:
    - Added private named constructor `UIComponent._` to centralize initialization.
    - Added public mirror constructor `UIComponent` with detailed documentation on parameters controlling rendering, styling, and structure.
    - Added new constructor `UIComponent.subComponent` for creating components attached to an existing `parentComponent`, sharing its DOM mapping context.
  - Updated `dispose` method to avoid disposing shared `domTreeMap` when the component is a subcomponent.

- `UIButton` (`button.dart`):
  - Extended `$uiButtonLoader` function to support additional attributes for loaded text styling and content:
    - Added parameters: `loadedTextClass`, `loadedTextStyle`, `loadedTextErrorClass`, `loadedTextErrorStyle`, `loadedTextOK`, `loadedTextError`.
    - Added corresponding attributes to the returned DOM element for these new parameters.